### PR TITLE
goRight movement

### DIFF
--- a/src/MultiwayTree.elm
+++ b/src/MultiwayTree.elm
@@ -1,8 +1,14 @@
-module MultiwayTree exposing
-    ( Tree (..), Forest
-    , datum, children
-    , map
-    )
+module MultiwayTree
+    exposing
+        ( Tree(..)
+        , Forest
+        , datum
+        , children
+        , map
+        , flatten
+        , foldr
+        , foldl
+        )
 
 {-| A library for constructing multi-way trees. Each Tree carries two pieces of
 information, it's datum and children.
@@ -18,33 +24,71 @@ information, it's datum and children.
 @docs map
 -}
 
+
 {-| A type to keep track of datum and children.
 -}
-type Tree a = Tree a (Forest a)
+type Tree a
+    = Tree a (Forest a)
 
 
 {-| A list of Trees. Convenient for describing children.
 -}
-type alias Forest a = List (Tree a)
+type alias Forest a =
+    List (Tree a)
 
 
 {-| Access the datum of the current tree
 -}
 datum : Tree a -> a
-datum (Tree datum children) = datum
+datum (Tree datum children) =
+    datum
 
 
 {-| Access the children of the current tree
 -}
 children : Tree a -> Forest a
-children (Tree datum children) = children
+children (Tree datum children) =
+    children
+
+
+{-| Reduce a Tree from the left.
+-}
+foldl : (a -> b -> b) -> b -> Tree a -> b
+foldl f accu (Tree datum children) =
+    let
+        treeUnwrap (Tree datum' children') accu' =
+            List.foldl treeUnwrap (f datum' accu') children'
+    in
+        List.foldl treeUnwrap (f datum accu) children
+
+
+{-| Reduce a Tree from the right.
+-}
+foldr : (a -> b -> b) -> b -> Tree a -> b
+foldr f accu (Tree datum children) =
+    let
+        treeUnwrap (Tree datum' children') accu' =
+            f datum' (List.foldr treeUnwrap accu' children')
+    in
+        f datum (List.foldr treeUnwrap accu children)
+
+
+{-| Flattens a Tree into a List where the root is the first element of that list.
+-}
+flatten : Tree a -> List a
+flatten tree =
+    foldr (::) [] tree
 
 
 {-| Map over the MultiwayTree
 -}
 map : (a -> b) -> Tree a -> Tree b
 map fn (Tree datum children) =
-    let mappedDatum = fn datum
-        mappedChildren = List.map (\child -> map fn child) children
+    let
+        mappedDatum =
+            fn datum
+
+        mappedChildren =
+            List.map (\child -> map fn child) children
     in
         (Tree mappedDatum mappedChildren)

--- a/src/MultiwayTreeZipper.elm
+++ b/src/MultiwayTreeZipper.elm
@@ -5,6 +5,7 @@ module MultiwayTreeZipper
         , Zipper
         , goToChild
         , goUp
+        , goRight
         , goToRoot
         , updateDatum
         , replaceDatum
@@ -151,9 +152,42 @@ goToChild n ( Tree datum children, breadcrumbs ) =
             splitOnIndex n children
     in
         case maybeSplit of
-            Nothing -> Nothing
-            Just (before, focus, after) ->
-                Just (focus, (Context datum before after) :: breadcrumbs )
+            Nothing ->
+                Nothing
+
+            Just ( before, focus, after ) ->
+                Just ( focus, (Context datum before after) :: breadcrumbs )
+
+
+{-| Move right relative to the current Zipper focus. This allows navigation from
+a child to it's next sibling.
+
+    (&>) = Maybe.andThen
+
+    simpleTree =
+        Tree "a"
+            [ Tree "b" []
+            , Tree "c" []
+            , Tree "d" []
+            ]
+
+    Just (simpleTree, [])
+        &> goToChild 1
+        &> goRight
+-}
+goRight : Zipper a -> Maybe (Zipper a)
+goRight ( tree, breadcrumbs ) =
+    case breadcrumbs of
+        (Context datum before after) :: bs ->
+            case after of
+                [] ->
+                    Nothing
+
+                (Tree nextDatum nextChildren) :: rest ->
+                    Just ( (Tree nextDatum nextChildren), (Context datum (before ++ [ tree ]) rest) :: bs )
+
+        [] ->
+            Nothing
 
 
 {-| Move to the root of the current Zipper focus. This allows navigation from

--- a/src/MultiwayTreeZipper.elm
+++ b/src/MultiwayTreeZipper.elm
@@ -1,10 +1,16 @@
-module MultiwayTreeZipper exposing
-    ( Context (..), Breadcrumbs, Zipper
-    , goToChild, goUp, goToRoot
-    , updateDatum, replaceDatum
-    , datum, maybeDatum
-    )
--- TODO: Add more documentation
+module MultiwayTreeZipper
+    exposing
+        ( Context(..)
+        , Breadcrumbs
+        , Zipper
+        , goToChild
+        , goUp
+        , goToRoot
+        , updateDatum
+        , replaceDatum
+        , datum
+        , maybeDatum
+        )
 
 {-| A library for navigating and updating immutable trees. The elements in
 the tree must have the same type. The trees are implemented in a Huet
@@ -33,10 +39,11 @@ Wanted the first version to be self contained.
 
 -}
 
-import List
-import Maybe exposing (Maybe (..))
+-- TODO: Add more documentation
 
-import MultiwayTree exposing (Tree (..), Forest, children)
+import List
+import Maybe exposing (Maybe(..))
+import MultiwayTree exposing (Tree(..), Forest, children)
 
 
 {-| The necessary information needed to reconstruct a MultiwayTree as it is
@@ -44,21 +51,25 @@ navigated with a Zipper. This context includes the datum that was at the
 previous node, a list of children that came before the node, and a list of
 children that came after the node.
 -}
-type Context a = Context a (List (Tree a)) (List (Tree a))
+type Context a
+    = Context a (List (Tree a)) (List (Tree a))
 
 
 {-| A list of Contexts that is contructed as a MultiwayTree is navigated.
 Breadcrumbs are used to retain information about parts of the tree that move out
 of focus. As the tree is navigated, the needed Context is pushed onto the list
 Breadcrumbs, and they are maintained in the reverse order in which they are
-visited -}
-type alias Breadcrumbs a = List (Context a)
+visited
+-}
+type alias Breadcrumbs a =
+    List (Context a)
 
 
 {-| A structure to keep track of the current Tree, as well as the Breadcrumbs to
 allow us to continue navigation through the rest of the tree.
 -}
-type alias Zipper a = (Tree a, Breadcrumbs a)
+type alias Zipper a =
+    ( Tree a, Breadcrumbs a )
 
 
 {-| Separate a list into three groups. This function is unique to MultiwayTree
@@ -72,15 +83,24 @@ The pieces are:
 
 These pieces help create a Context, which assist the Zipper
 -}
-splitOnIndex : Int -> List (Tree a) -> Maybe (List (Tree a), Tree a, List (Tree a))
+splitOnIndex : Int -> List (Tree a) -> Maybe ( List (Tree a), Tree a, List (Tree a) )
 splitOnIndex n xs =
-    let before = List.take n xs
-        focus = List.drop n xs |> List.head
-        after = List.drop (n + 1) xs
+    let
+        before =
+            List.take n xs
+
+        focus =
+            List.drop n xs |> List.head
+
+        after =
+            List.drop (n + 1) xs
     in
         case focus of
-            Nothing -> Nothing
-            Just f -> Just (before, f, after)
+            Nothing ->
+                Nothing
+
+            Just f ->
+                Just ( before, f, after )
 
 
 {-| Move up relative to the current Zipper focus. This allows navigation from a
@@ -100,11 +120,13 @@ child to it's parent.
         &> goUp
 -}
 goUp : Zipper a -> Maybe (Zipper a)
-goUp (tree, breadcrumbs) =
+goUp ( tree, breadcrumbs ) =
     case breadcrumbs of
         (Context datum before after) :: bs ->
-            Just (Tree datum (before ++ [tree] ++ after), bs)
-        [] -> Nothing
+            Just ( Tree datum (before ++ [ tree ] ++ after), bs )
+
+        [] ->
+            Nothing
 
 
 {-| Move down relative to the current Zipper focus. This allows navigation from
@@ -123,8 +145,10 @@ a parent to it's children.
         &> goToChild 1
 -}
 goToChild : Int -> Zipper a -> Maybe (Zipper a)
-goToChild n (Tree datum children, breadcrumbs) =
-    let maybeSplit = splitOnIndex n children
+goToChild n ( Tree datum children, breadcrumbs ) =
+    let
+        maybeSplit =
+            splitOnIndex n children
     in
         case maybeSplit of
             Nothing -> Nothing
@@ -151,10 +175,13 @@ any part of the tree back to the root.
         &> goToRoot
 -}
 goToRoot : Zipper a -> Maybe (Zipper a)
-goToRoot (tree, breadcrumbs) =
+goToRoot ( tree, breadcrumbs ) =
     case breadcrumbs of
-        [] -> Just (tree, breadcrumbs)
-        otherwise -> goUp (tree, breadcrumbs) `Maybe.andThen` goToRoot
+        [] ->
+            Just ( tree, breadcrumbs )
+
+        otherwise ->
+            goUp ( tree, breadcrumbs ) `Maybe.andThen` goToRoot
 
 
 {-| Update the datum at the current Zipper focus. This allows changes to be made
@@ -176,8 +203,8 @@ to a part of a node's datum information, given the previous state of the node.
         &> goToRoot
 -}
 updateDatum : (a -> a) -> Zipper a -> Maybe (Zipper a)
-updateDatum fn (Tree datum children, breadcrumbs) =
-    Just (Tree (fn datum) children, breadcrumbs)
+updateDatum fn ( Tree datum children, breadcrumbs ) =
+    Just ( Tree (fn datum) children, breadcrumbs )
 
 
 {-| Replace the datum at the current Zipper focus. This allows complete
@@ -207,14 +234,14 @@ replaceDatum newDatum =
 {-| Fully replace the children at the current Zipper focus.
 -}
 updateChildren : Forest a -> Zipper a -> Zipper a
-updateChildren newChildren (Tree datum children, breadcrumbs) =
-    (Tree datum newChildren, breadcrumbs)
+updateChildren newChildren ( Tree datum children, breadcrumbs ) =
+    ( Tree datum newChildren, breadcrumbs )
 
 
 {-| Access the datum at the current Zipper focus.
 -}
 datum : Zipper a -> a
-datum (tree, breadcrumbs) =
+datum ( tree, breadcrumbs ) =
     MultiwayTree.datum tree
 
 

--- a/tests/Test/FlattenTests.elm
+++ b/tests/Test/FlattenTests.elm
@@ -1,0 +1,29 @@
+module Test.FlattenTests exposing (..)
+
+import ElmTest exposing (..)
+import MultiwayTree exposing (Tree(..))
+import MultiwayTreeZipper exposing (..)
+import Test.SampleData
+    exposing
+        ( noChildTree
+        , singleChildTree
+        , multiChildTree
+        , deepTree
+        , noChildRecord
+        , interestingTree
+        )
+
+
+tests : Test
+tests =
+    suite "Flatten"
+        [ test "Flatten multiChildTree"
+            <| assertEqual [ "a", "b", "c", "d" ]
+                (MultiwayTree.flatten multiChildTree)
+        , test "Flatten deepTree"
+            <| assertEqual [ "a", "b", "c", "d" ]
+                (MultiwayTree.flatten deepTree)
+        , test "Flatten interestingTree"
+            <| assertEqual [ "a", "b", "e", "k", "c", "f", "g", "d", "h", "i", "j" ]
+                (MultiwayTree.flatten interestingTree)
+        ]

--- a/tests/Test/FoldTests.elm
+++ b/tests/Test/FoldTests.elm
@@ -1,0 +1,23 @@
+module Test.FoldTests exposing (..)
+
+import ElmTest exposing (..)
+import MultiwayTree exposing (Tree(..))
+import MultiwayTreeZipper exposing (..)
+import Test.SampleData
+    exposing
+        ( noChildTree
+        , singleChildTree
+        , multiChildTree
+        , deepTree
+        , noChildRecord
+        , interestingTree
+        )
+
+
+tests : Test
+tests =
+    suite "Fold"
+        [ test "Foldl interestingTree into List"
+            <| assertEqual (MultiwayTree.flatten interestingTree)
+                ((MultiwayTree.foldl (::) [] interestingTree) |> List.reverse)
+        ]

--- a/tests/Test/MultiwayTreeZipper.elm
+++ b/tests/Test/MultiwayTreeZipper.elm
@@ -1,19 +1,24 @@
 module Test.MultiwayTreeZipper exposing (tests)
 
 import ElmTest exposing (..)
-
-import MultiwayTree exposing (Tree (..))
+import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
-
 import Test.SampleData exposing (singleChildTree, multiChildTree, deepTree)
 import Test.NavigationTests
 import Test.UpdateTests
+import Test.FlattenTests
+import Test.FoldTests
 
-(&>) = Maybe.andThen
+
+(&>) =
+    Maybe.andThen
+
 
 tests : Test
 tests =
     suite "MultiwayTreeZipper"
         [ Test.NavigationTests.tests
         , Test.UpdateTests.tests
+        , Test.FlattenTests.tests
+        , Test.FoldTests.tests
         ]

--- a/tests/Test/NavigationTests.elm
+++ b/tests/Test/NavigationTests.elm
@@ -1,81 +1,117 @@
 module Test.NavigationTests exposing (..)
 
 import ElmTest exposing (..)
-
-import MultiwayTree exposing (Tree (..))
+import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
-import Test.SampleData exposing (singleChildTree, multiChildTree, deepTree)
+import Test.SampleData exposing (singleChildTree, multiChildTree, deepTree, noChildTree)
 
-(&>) = Maybe.andThen
+
+(&>) =
+    Maybe.andThen
+
 
 tests : Test
 tests =
     suite "Navigation"
-          [ test "Navigate to child (only child)"
-              <| assertEqual
-                (Just ((Tree "b" [] ), [ Context "a" [] [] ]))
-                (Just (singleChildTree, [])
-                    &> goToChild 0)
-
-          , test "Navigate to child (one of many)"
-              <| assertEqual
-                (Just
-                    ((Tree "c" [] ) ,
-                     [ Context "a"
-                        [ (Tree "b" []) ]
-                        [ (Tree "d" []) ]
-                     ])
+        [ test "Navigate to child (only child)"
+            <| assertEqual (Just ( (Tree "b" []), [ Context "a" [] [] ] ))
+                (Just ( singleChildTree, [] )
+                    &> goToChild 0
                 )
-                (Just (multiChildTree, [])
-                    &> goToChild 1)
-
-          , test "Navigate to a child (deep)"
-              <| assertEqual
-                (Just ((Tree "d" [] ),
-                [ Context "c" [] []
-                , Context "b" [] []
-                , Context "a" [] []
-                ]))
-                (Just (deepTree, [])
-                    &> goToChild 0
-                    &> goToChild 0
-                    &> goToChild 0)
-
-          , test "Navigate up (single level)"
-              <| assertEqual
-                (Just ((Tree "a" [ Tree "b" [] ]), [] ))
-                (Just (singleChildTree, [])
-                    &> goToChild 0
-                    &> goUp)
-
-          , test "Navigate up (single level with many children)"
-              <| assertEqual
-                (Just ((Tree "a" [ Tree "b" [], Tree "c" [], Tree "d" [] ]), [] ))
-                (Just (multiChildTree, [])
+        , test "Navigate to child (one of many)"
+            <| assertEqual
+                (Just
+                    ( (Tree "c" [])
+                    , [ Context "a"
+                            [ (Tree "b" []) ]
+                            [ (Tree "d" []) ]
+                      ]
+                    )
+                )
+                (Just ( multiChildTree, [] )
                     &> goToChild 1
-                    &> goUp)
-
-          , test "Navigate up from a child (deep)"
-              <| assertEqual
-                (Just ((Tree "a" [ Tree "b" [ Tree "c" [ Tree "d" [] ]]]), []))
-                (Just (deepTree, [])
+                )
+        , test "Navigate to a child (deep)"
+            <| assertEqual
+                (Just
+                    ( (Tree "d" [])
+                    , [ Context "c" [] []
+                      , Context "b" [] []
+                      , Context "a" [] []
+                      ]
+                    )
+                )
+                (Just ( deepTree, [] )
+                    &> goToChild 0
+                    &> goToChild 0
+                    &> goToChild 0
+                )
+        , test "Navigate up (single level)"
+            <| assertEqual (Just ( (Tree "a" [ Tree "b" [] ]), [] ))
+                (Just ( singleChildTree, [] )
+                    &> goToChild 0
+                    &> goUp
+                )
+        , test "Navigate up (single level with many children)"
+            <| assertEqual (Just ( (Tree "a" [ Tree "b" [], Tree "c" [], Tree "d" [] ]), [] ))
+                (Just ( multiChildTree, [] )
+                    &> goToChild 1
+                    &> goUp
+                )
+        , test "Navigate up from a child (deep)"
+            <| assertEqual (Just ( (Tree "a" [ Tree "b" [ Tree "c" [ Tree "d" [] ] ] ]), [] ))
+                (Just ( deepTree, [] )
                     &> goToChild 0
                     &> goToChild 0
                     &> goToChild 0
                     &> goUp
                     &> goUp
-                    &> goUp)
-
-          , test "Navigate beyond the tree (only child)"
-              <| assertEqual
-                Nothing
-                (Just (singleChildTree, [])
+                    &> goUp
+                )
+        , test "Navigate beyond the tree (only child)"
+            <| assertEqual Nothing
+                (Just ( singleChildTree, [] )
                     &> goToChild 0
-                    &> goToChild 0)
-
-          , test "Navigate beyond the tree (up past root)"
-              <| assertEqual
-                Nothing
-                (Just (singleChildTree, [])
-                    &> goUp)
-          ]
+                    &> goToChild 0
+                )
+        , test "Navigate beyond the tree (up past root)"
+            <| assertEqual Nothing
+                (Just ( singleChildTree, [] )
+                    &> goUp
+                )
+        , test "Navigate to right sibling on no child tree does not work"
+            <| assertEqual Nothing
+                (Just ( noChildTree, [] )
+                    &> goRight
+                )
+        , test "Navigate to right child"
+            <| assertEqual
+                (Just
+                    ( (Tree "c" [])
+                    , [ Context "a"
+                            [ (Tree "b" []) ]
+                            [ (Tree "d" []) ]
+                      ]
+                    )
+                )
+                (Just ( multiChildTree, [] )
+                    &> goToChild 0
+                    &> goRight
+                )
+        , test "Navigate to right child twice"
+            <| assertEqual
+                (Just ( multiChildTree, [] )
+                    &> goToChild 2
+                )
+                (Just ( multiChildTree, [] )
+                    &> goToChild 0
+                    &> goRight
+                    &> goRight
+                )
+        , test "Navigate to right child when there are no siblings left return Nothing"
+            <| assertEqual Nothing
+                (Just ( multiChildTree, [] )
+                    &> goToChild 2
+                    &> goRight
+                )
+        ]


### PR DESCRIPTION
This PR adds a goRight movement command which will move to the next sibling node if one is present else it will return Nothing
