### PR TITLE
Export updateChildren and add to @docs

### DIFF
--- a/src/MultiwayTreeZipper.elm
+++ b/src/MultiwayTreeZipper.elm
@@ -18,6 +18,7 @@ module MultiwayTreeZipper
         , maybeDatum
         , insertChild
         , appendChild
+        , updateChildren
         )
 
 {-| A library for navigating and updating immutable trees. The elements in
@@ -31,7 +32,7 @@ Zipper fashion.
 @docs goToChild, goUp, goToRoot, goLeft, goRight, goToNext, goToPrevious, goToRightMostChild, goTo
 
 # Update API
-@docs updateDatum, replaceDatum, insertChild, appendChild
+@docs updateDatum, replaceDatum, insertChild, appendChild, updateChildren
 
 # Access API
 @docs datum, maybeDatum


### PR DESCRIPTION
I needed to update children in my tree, but I saw only `appendChild` and `insertChild`, so I looked at the source and I found `updateChildren`. But it seems this function was forgotten in the exports and the `@docs` tag, if I'm right.

Here is my fix, what do you think about it?
