### PR TITLE
Elm 0.18.0 support

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.0",
+    "version": "1.11.0",
     "summary": "A library for navigating and updating immutable trees.",
     "repository": "https://github.com/tomjkidd/elm-multiway-tree-zipper.git",
     "license": "BSD3",
@@ -12,7 +12,7 @@
         "MultiwayTreeZipper"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.11.0",
+    "version": "1.10.1",
     "summary": "A library for navigating and updating immutable trees.",
     "repository": "https://github.com/tomjkidd/elm-multiway-tree-zipper.git",
     "license": "BSD3",

--- a/src/MultiwayTree.elm
+++ b/src/MultiwayTree.elm
@@ -83,8 +83,8 @@ appendChild childTree (Tree datum children) =
 foldl : (a -> b -> b) -> b -> Tree a -> b
 foldl f accu (Tree datum children) =
     let
-        treeUnwrap (Tree datum' children') accu' =
-            List.foldl treeUnwrap (f datum' accu') children'
+        treeUnwrap (Tree datum_ children_) accu_ =
+            List.foldl treeUnwrap (f datum_ accu_) children_
     in
         List.foldl treeUnwrap (f datum accu) children
 
@@ -94,8 +94,8 @@ foldl f accu (Tree datum children) =
 foldr : (a -> b -> b) -> b -> Tree a -> b
 foldr f accu (Tree datum children) =
     let
-        treeUnwrap (Tree datum' children') accu' =
-            f datum' (List.foldr treeUnwrap accu' children')
+        treeUnwrap (Tree datum_ children_) accu_ =
+            f datum_ (List.foldr treeUnwrap accu_ children_)
     in
         f datum (List.foldr treeUnwrap accu children)
 
@@ -176,11 +176,11 @@ mapListOverTree fn list (Tree datum children) =
 
 splitByLength : List Int -> List a -> List (List a)
 splitByLength listOflengths list =
-    splitByLength' listOflengths list []
+    splitByLength_ listOflengths list []
 
 
-splitByLength' : List Int -> List a -> List (List a) -> List (List a)
-splitByLength' listOflengths list accu =
+splitByLength_ : List Int -> List a -> List (List a) -> List (List a)
+splitByLength_ listOflengths list accu =
     case listOflengths of
         [] ->
             List.reverse accu
@@ -191,14 +191,14 @@ splitByLength' listOflengths list accu =
                     List.reverse accu
 
                 head :: rest ->
-                    splitByLength' restLengths (List.drop currentLength list) ((List.take currentLength list) :: accu)
+                    splitByLength_ restLengths (List.drop currentLength list) ((List.take currentLength list) :: accu)
 
 
 {-| Same as map but the function is also applied to the index of each element (starting at zero).
 -}
 indexedMap : (Int -> a -> b) -> Tree a -> Maybe (Tree b)
 indexedMap f tree =
-    mapListOverTree f [0..(length tree - 1)] tree
+    mapListOverTree f (List.range 0 (length tree - 1)) tree
 
 
 {-| Filter the MultiwayTree. Keep only elements whose datum satisfy the predicate.
@@ -222,8 +222,8 @@ filterWithChildPrecedence predicate (Tree datum children) =
             else
                 Nothing
 
-        children' ->
-            Just (Tree datum children')
+        children_ ->
+            Just (Tree datum children_)
 
 
 {-| Sort values by a derived property. Does not alter the nesting structure of
@@ -245,7 +245,7 @@ sortBy : (a -> comparable) -> Tree a -> Tree a
 sortBy fn (Tree datum children) =
     let
         sortedChildren =
-            List.sortBy (\(Tree childDatum children') -> fn childDatum) children
+            List.sortBy (\(Tree childDatum children_) -> fn childDatum) children
                 |> List.map (sortBy fn)
     in
         (Tree datum sortedChildren)

--- a/src/MultiwayTreeZipper.elm
+++ b/src/MultiwayTreeZipper.elm
@@ -214,8 +214,8 @@ goLeft ( tree, breadcrumbs ) =
                 [] ->
                     Nothing
 
-                tree' :: rest ->
-                    Just ( tree', (Context datum (List.reverse rest) (tree :: after)) :: bs )
+                tree_ :: rest ->
+                    Just ( tree_, (Context datum (List.reverse rest) (tree :: after)) :: bs )
 
 
 {-| Move right relative to the current Zipper focus. This allows navigation from
@@ -268,17 +268,17 @@ goRight ( tree, breadcrumbs ) =
 goToPrevious : Zipper a -> Maybe (Zipper a)
 goToPrevious zipper =
     let
-        recurseDownAndRight zipper' =
-            case goToRightMostChild zipper' of
-                Just zipper'' ->
-                    recurseDownAndRight zipper''
+        recurseDownAndRight zipper_ =
+            case goToRightMostChild zipper_ of
+                Just zipper__ ->
+                    recurseDownAndRight zipper__
 
                 Nothing ->
-                    Just zipper'
+                    Just zipper_
     in
         case goLeft zipper of
-            Just zipper' ->
-                recurseDownAndRight zipper'
+            Just zipper_ ->
+                recurseDownAndRight zipper_
 
             Nothing ->
                 goUp zipper
@@ -308,30 +308,30 @@ goToNext zipper =
                 Nothing ->
                     Nothing
 
-                Just zipper' ->
-                    case goRight zipper' of
+                Just zipper_ ->
+                    case goRight zipper_ of
                         Nothing ->
-                            upAndOver zipper'
+                            upAndOver zipper_
 
-                        zipper'' ->
-                            zipper''
+                        zipper__ ->
+                            zipper__
     in
         case goToChild 0 zipper of
-            Just zipper' ->
-                Just zipper'
+            Just zipper_ ->
+                Just zipper_
 
             Nothing ->
                 case goRight zipper of
-                    Just zipper' ->
-                        Just zipper'
+                    Just zipper_ ->
+                        Just zipper_
 
                     Nothing ->
                         case upAndOver zipper of
                             Nothing ->
                                 Nothing
 
-                            zipper' ->
-                                zipper'
+                            zipper_ ->
+                                zipper_
 
 
 {-| Move to the root of the current Zipper focus. This allows navigation from
@@ -359,7 +359,7 @@ goToRoot ( tree, breadcrumbs ) =
             Just ( tree, breadcrumbs )
 
         otherwise ->
-            goUp ( tree, breadcrumbs ) `Maybe.andThen` goToRoot
+            goUp ( tree, breadcrumbs ) |> Maybe.andThen goToRoot
 
 
 {-| Move the focus to the first element for which the predicate is True. If no
@@ -385,9 +385,9 @@ goTo predicate zipper =
             if predicate datum then
                 Just ( Tree datum children, breadcrumbs )
             else
-                goToNext ( Tree datum children, breadcrumbs ) `Maybe.andThen` goToElementOrNext
+                goToNext ( Tree datum children, breadcrumbs ) |> Maybe.andThen goToElementOrNext
     in
-        (goToRoot zipper) `Maybe.andThen` goToElementOrNext
+        (goToRoot zipper) |> Maybe.andThen goToElementOrNext
 
 
 {-| Update the datum at the current Zipper focus. This allows changes to be made

--- a/tests/Test/AppendTests.elm
+++ b/tests/Test/AppendTests.elm
@@ -1,6 +1,6 @@
 module Test.AppendTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData
@@ -12,19 +12,17 @@ import Test.SampleData
         , noChildRecord
         , interestingTree
         )
-
-
-(&>) =
-    Maybe.andThen
+import Test.Utils exposing (..)
 
 
 tests : Test
 tests =
     suite "Append"
-        [ test "appending children can turn a multiChildTree into an interestingTree"
-            <| assertEqual (Just ( interestingTree, [] ))
+        [ test "appending children can turn a multiChildTree into an interestingTree" <|
+            assertEqual (Just ( interestingTree, [] ))
                 (Just ( multiChildTree, [] )
-                    &> goToChild 0
+                    &> goToChild
+                        0
                     &> appendChild (Tree "e" [])
                     &> goToChild 0
                     &> appendChild (Tree "k" [])

--- a/tests/Test/FilterTests.elm
+++ b/tests/Test/FilterTests.elm
@@ -1,6 +1,6 @@
 module Test.FilterTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData

--- a/tests/Test/FilterWithChildPrecedenceTests.elm
+++ b/tests/Test/FilterWithChildPrecedenceTests.elm
@@ -1,6 +1,6 @@
 module Test.FilterWithChildPrecedenceTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData

--- a/tests/Test/FlattenTests.elm
+++ b/tests/Test/FlattenTests.elm
@@ -1,6 +1,6 @@
 module Test.FlattenTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData

--- a/tests/Test/FoldTests.elm
+++ b/tests/Test/FoldTests.elm
@@ -1,6 +1,6 @@
 module Test.FoldTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData

--- a/tests/Test/IndexedMapTests.elm
+++ b/tests/Test/IndexedMapTests.elm
@@ -1,6 +1,6 @@
 module Test.IndexedMapTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData
@@ -17,8 +17,8 @@ import Test.SampleData
 tests : Test
 tests =
     suite "IndexedMap"
-        [ test "Maps a function with index over the Tree, transforms Tree"
-            <| assertEqual [0..10]
+        [ test "Maps a function with index over the Tree, transforms Tree" <|
+            assertEqual (List.range 0 10)
                 (case MultiwayTree.indexedMap (\index c -> index) interestingTree of
                     Just tree ->
                         (MultiwayTree.flatten tree)

--- a/tests/Test/InsertTests.elm
+++ b/tests/Test/InsertTests.elm
@@ -1,6 +1,6 @@
 module Test.InsertTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData
@@ -12,17 +12,14 @@ import Test.SampleData
         , noChildRecord
         , interestingTree
         )
-
-
-(&>) =
-    Maybe.andThen
+import Test.Utils exposing (..)
 
 
 tests : Test
 tests =
     suite "Insert"
-        [ test "Inserting children can turn a multiChildTree into an interestingTree"
-            <| assertEqual (Just ( interestingTree, [] ))
+        [ test "Inserting children can turn a multiChildTree into an interestingTree" <|
+            assertEqual (Just ( interestingTree, [] ))
                 (Just ( multiChildTree, [] )
                     &> goToChild 0
                     &> insertChild (Tree "e" [])

--- a/tests/Test/LengthTests.elm
+++ b/tests/Test/LengthTests.elm
@@ -1,6 +1,6 @@
 module Test.LengthTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData
@@ -17,16 +17,16 @@ import Test.SampleData
 tests : Test
 tests =
     suite "Length"
-        [ test "Length of an interesting Tree"
-            <| assertEqual 11
+        [ test "Length of an interesting Tree" <|
+            assertEqual 11
                 (MultiwayTree.length interestingTree)
-        , test "Length of a noChildTree"
-            <| assertEqual 1
+        , test "Length of a noChildTree" <|
+            assertEqual 1
                 (MultiwayTree.length noChildTree)
-        , test "Length of a deepTree"
-            <| assertEqual 4
+        , test "Length of a deepTree" <|
+            assertEqual 4
                 (MultiwayTree.length deepTree)
-        , test "Length of a Tree is equal to length of a flattened tree"
-            <| assertEqual (List.length (MultiwayTree.flatten interestingTree))
+        , test "Length of a Tree is equal to length of a flattened tree" <|
+            assertEqual (List.length (MultiwayTree.flatten interestingTree))
                 (MultiwayTree.length interestingTree)
         ]

--- a/tests/Test/MultiwayTreeZipper.elm
+++ b/tests/Test/MultiwayTreeZipper.elm
@@ -1,6 +1,6 @@
 module Test.MultiwayTreeZipper exposing (tests)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import Test.NavigationTests
 import Test.UpdateTests
 import Test.FlattenTests

--- a/tests/Test/NavigationTests.elm
+++ b/tests/Test/NavigationTests.elm
@@ -1,25 +1,22 @@
 module Test.NavigationTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData exposing (singleChildTree, multiChildTree, deepTree, noChildTree, interestingTree)
-
-
-(&>) =
-    Maybe.andThen
+import Test.Utils exposing (..)
 
 
 tests : Test
 tests =
     suite "Navigation"
-        [ test "Navigate to child (only child)"
-            <| assertEqual (Just ( (Tree "b" []), [ Context "a" [] [] ] ))
+        [ test "Navigate to child (only child)" <|
+            assertEqual (Just ( (Tree "b" []), [ Context "a" [] [] ] ))
                 (Just ( singleChildTree, [] )
                     &> goToChild 0
                 )
-        , test "Navigate to child (one of many)"
-            <| assertEqual
+        , test "Navigate to child (one of many)" <|
+            assertEqual
                 (Just
                     ( (Tree "c" [])
                     , [ Context "a"
@@ -31,8 +28,8 @@ tests =
                 (Just ( multiChildTree, [] )
                     &> goToChild 1
                 )
-        , test "Navigate to a child (deep)"
-            <| assertEqual
+        , test "Navigate to a child (deep)" <|
+            assertEqual
                 (Just
                     ( (Tree "d" [])
                     , [ Context "c" [] []
@@ -46,29 +43,29 @@ tests =
                     &> goToChild 0
                     &> goToChild 0
                 )
-        , test "Navigate to last child of an empty tree returns Nothing"
-            <| assertEqual Nothing
+        , test "Navigate to last child of an empty tree returns Nothing" <|
+            assertEqual Nothing
                 (Just ( noChildTree, [] )
                     &> goToRightMostChild
                 )
-        , test "Navigate to last child of a tree with just one child moves to that child"
-            <| assertEqual
+        , test "Navigate to last child of a tree with just one child moves to that child" <|
+            assertEqual
                 (Just ( singleChildTree, [] )
                     &> goToChild 0
                 )
                 (Just ( singleChildTree, [] )
                     &> goToRightMostChild
                 )
-        , test "Navigate to last child of a tree with multiple children moves to the last child"
-            <| assertEqual
+        , test "Navigate to last child of a tree with multiple children moves to the last child" <|
+            assertEqual
                 (Just ( multiChildTree, [] )
                     &> goToChild 2
                 )
                 (Just ( multiChildTree, [] )
                     &> goToRightMostChild
                 )
-        , test "Navigate to last child of an interestingTree"
-            <| assertEqual
+        , test "Navigate to last child of an interestingTree" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 2
                     &> goToChild 2
@@ -77,20 +74,20 @@ tests =
                     &> goToRightMostChild
                     &> goToRightMostChild
                 )
-        , test "Navigate up (single level)"
-            <| assertEqual (Just ( (Tree "a" [ Tree "b" [] ]), [] ))
+        , test "Navigate up (single level)" <|
+            assertEqual (Just ( (Tree "a" [ Tree "b" [] ]), [] ))
                 (Just ( singleChildTree, [] )
                     &> goToChild 0
                     &> goUp
                 )
-        , test "Navigate up (single level with many children)"
-            <| assertEqual (Just ( (Tree "a" [ Tree "b" [], Tree "c" [], Tree "d" [] ]), [] ))
+        , test "Navigate up (single level with many children)" <|
+            assertEqual (Just ( (Tree "a" [ Tree "b" [], Tree "c" [], Tree "d" [] ]), [] ))
                 (Just ( multiChildTree, [] )
                     &> goToChild 1
                     &> goUp
                 )
-        , test "Navigate up from a child (deep)"
-            <| assertEqual (Just ( (Tree "a" [ Tree "b" [ Tree "c" [ Tree "d" [] ] ] ]), [] ))
+        , test "Navigate up from a child (deep)" <|
+            assertEqual (Just ( (Tree "a" [ Tree "b" [ Tree "c" [ Tree "d" [] ] ] ]), [] ))
                 (Just ( deepTree, [] )
                     &> goToChild 0
                     &> goToChild 0
@@ -99,24 +96,24 @@ tests =
                     &> goUp
                     &> goUp
                 )
-        , test "Navigate beyond the tree (only child)"
-            <| assertEqual Nothing
+        , test "Navigate beyond the tree (only child)" <|
+            assertEqual Nothing
                 (Just ( singleChildTree, [] )
                     &> goToChild 0
                     &> goToChild 0
                 )
-        , test "Navigate beyond the tree (up past root)"
-            <| assertEqual Nothing
+        , test "Navigate beyond the tree (up past root)" <|
+            assertEqual Nothing
                 (Just ( singleChildTree, [] )
                     &> goUp
                 )
-        , test "Navigate to left sibling on no child tree does not work"
-            <| assertEqual Nothing
+        , test "Navigate to left sibling on no child tree does not work" <|
+            assertEqual Nothing
                 (Just ( noChildTree, [] )
                     &> goLeft
                 )
-        , test "Navigate to left child"
-            <| assertEqual
+        , test "Navigate to left child" <|
+            assertEqual
                 (Just ( multiChildTree, [] )
                     &> goToChild 0
                     &> goRight
@@ -125,8 +122,8 @@ tests =
                     &> goToChild 2
                     &> goLeft
                 )
-        , test "Navigate to left child twice"
-            <| assertEqual
+        , test "Navigate to left child twice" <|
+            assertEqual
                 (Just ( multiChildTree, [] )
                     &> goToChild 0
                 )
@@ -135,19 +132,19 @@ tests =
                     &> goLeft
                     &> goLeft
                 )
-        , test "Navigate to left child when there are no siblings left return Nothing"
-            <| assertEqual Nothing
+        , test "Navigate to left child when there are no siblings left return Nothing" <|
+            assertEqual Nothing
                 (Just ( multiChildTree, [] )
                     &> goToChild 0
                     &> goLeft
                 )
-        , test "Navigate to right sibling on no child tree does not work"
-            <| assertEqual Nothing
+        , test "Navigate to right sibling on no child tree does not work" <|
+            assertEqual Nothing
                 (Just ( noChildTree, [] )
                     &> goRight
                 )
-        , test "Navigate to right child"
-            <| assertEqual
+        , test "Navigate to right child" <|
+            assertEqual
                 (Just
                     ( (Tree "c" [])
                     , [ Context "a"
@@ -160,8 +157,8 @@ tests =
                     &> goToChild 0
                     &> goRight
                 )
-        , test "Navigate to right child twice"
-            <| assertEqual
+        , test "Navigate to right child twice" <|
+            assertEqual
                 (Just ( multiChildTree, [] )
                     &> goToChild 2
                 )
@@ -170,19 +167,19 @@ tests =
                     &> goRight
                     &> goRight
                 )
-        , test "Navigate to right child when there are no siblings left return Nothing"
-            <| assertEqual Nothing
+        , test "Navigate to right child when there are no siblings left return Nothing" <|
+            assertEqual Nothing
                 (Just ( multiChildTree, [] )
                     &> goToChild 2
                     &> goRight
                 )
-        , test "Navigate to next child on Tree with just one node"
-            <| assertEqual Nothing
+        , test "Navigate to next child on Tree with just one node" <|
+            assertEqual Nothing
                 (Just ( noChildTree, [] )
                     &> goToNext
                 )
-        , test "Navigate to next child on an interesting tree will select the next node"
-            <| assertEqual
+        , test "Navigate to next child on an interesting tree will select the next node" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 0
                     &> goToChild 0
@@ -191,8 +188,8 @@ tests =
                     &> goToChild 0
                     &> goToNext
                 )
-        , test "Navigate to next child when the end of a branch has been reached will perform backtracking until the next node down can be reached"
-            <| assertEqual
+        , test "Navigate to next child when the end of a branch has been reached will perform backtracking until the next node down can be reached" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 1
                 )
@@ -202,16 +199,16 @@ tests =
                     &> goToChild 0
                     &> goToNext
                 )
-        , test "Navigating past the end of a Tree will return Nothing"
-            <| assertEqual Nothing
+        , test "Navigating past the end of a Tree will return Nothing" <|
+            assertEqual Nothing
                 (Just ( deepTree, [] )
                     &> goToNext
                     &> goToNext
                     &> goToNext
                     &> goToNext
                 )
-        , test "Consecutive goToNext on an interestingTree end up on the right Node"
-            <| assertEqual
+        , test "Consecutive goToNext on an interestingTree end up on the right Node" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 2
                     &> goToChild 1
@@ -227,8 +224,8 @@ tests =
                     &> goToNext
                     &> goToNext
                 )
-        , test "Navigate to previous child when there are siblings will select the sibling"
-            <| assertEqual
+        , test "Navigate to previous child when there are siblings will select the sibling" <|
+            assertEqual
                 (Just ( multiChildTree, [] )
                     &> goToChild 1
                 )
@@ -236,8 +233,8 @@ tests =
                     &> goToChild 2
                     &> goToPrevious
                 )
-        , test "Navigate to previous child on an interesting tree will select the previous node"
-            <| assertEqual
+        , test "Navigate to previous child on an interesting tree will select the previous node" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 0
                 )
@@ -246,8 +243,8 @@ tests =
                     &> goToChild 0
                     &> goToPrevious
                 )
-        , test "Navigate to previous child when the beginning of a branch has been reached will perform backtracking until the next node down can be reached"
-            <| assertEqual
+        , test "Navigate to previous child when the beginning of a branch has been reached will perform backtracking until the next node down can be reached" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 0
                     &> goToChild 0
@@ -257,15 +254,15 @@ tests =
                     &> goToChild 1
                     &> goToPrevious
                 )
-        , test "Navigating past the beginning of a Tree will return Nothing"
-            <| assertEqual Nothing
+        , test "Navigating past the beginning of a Tree will return Nothing" <|
+            assertEqual Nothing
                 (Just ( singleChildTree, [] )
                     &> goToChild 0
                     &> goToPrevious
                     &> goToPrevious
                 )
-        , test "Consecutive goToPrevious on an interestingTree end up on the right Node"
-            <| assertEqual
+        , test "Consecutive goToPrevious on an interestingTree end up on the right Node" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 0
                 )
@@ -282,13 +279,13 @@ tests =
                     &> goToPrevious
                     &> goToPrevious
                 )
-        , test "Trying to find a non existing element in a Tree returns Nothing"
-            <| assertEqual Nothing
+        , test "Trying to find a non existing element in a Tree returns Nothing" <|
+            assertEqual Nothing
                 (Just ( interestingTree, [] )
                     &> goTo (\elem -> elem == "FOO")
                 )
-        , test "Trying to find an existing element in a Tree moves the focus to this element"
-            <| assertEqual
+        , test "Trying to find an existing element in a Tree moves the focus to this element" <|
+            assertEqual
                 (Just ( interestingTree, [] )
                     &> goToChild 2
                     &> goToChild 0

--- a/tests/Test/SampleData.elm
+++ b/tests/Test/SampleData.elm
@@ -1,6 +1,7 @@
 module Test.SampleData exposing (..)
 
-import MultiwayTree exposing (Tree (..), Forest)
+import MultiwayTree exposing (Tree(..), Forest)
+
 
 interestingTree : Tree String
 interestingTree =
@@ -20,15 +21,19 @@ interestingTree =
             ]
         ]
 
+
 noChildTree =
     Tree "a" []
+
 
 noChildRecord =
     Tree { selected = False, expanded = False } []
 
+
 singleChildTree =
     Tree "a"
         [ Tree "b" [] ]
+
 
 multiChildTree =
     Tree "a"
@@ -37,6 +42,7 @@ multiChildTree =
         , Tree "d" []
         ]
 
+
 deepTree =
     Tree "a"
         [ Tree "b"
@@ -44,6 +50,7 @@ deepTree =
                 [ Tree "d" [] ]
             ]
         ]
+
 
 simpleForest =
     [ (Tree "x" [])

--- a/tests/Test/SortTests.elm
+++ b/tests/Test/SortTests.elm
@@ -1,6 +1,6 @@
 module Test.SortTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import Test.SampleData
     exposing
@@ -67,16 +67,16 @@ flippedComparison a b =
 tests : Test
 tests =
     suite "Sort"
-        [ test "Sorting a Tree with only one child per levels yields the same Tree"
-            <| assertEqual deepTree
+        [ test "Sorting a Tree with only one child per levels yields the same Tree" <|
+            assertEqual deepTree
                 (MultiwayTree.sortBy identity deepTree)
-        , test "Sorting a sorted Tree returns the same Tree"
-            <| assertEqual interestingTree
+        , test "Sorting a sorted Tree returns the same Tree" <|
+            assertEqual interestingTree
                 (MultiwayTree.sortBy identity interestingTree)
-        , test "Sorting an unsorted Tree returns a sorted Tree"
-            <| assertEqual interestingTree
+        , test "Sorting an unsorted Tree returns a sorted Tree" <|
+            assertEqual interestingTree
                 (MultiwayTree.sortBy identity unorderedTree)
-        , test "Sorting with a Tree with a reversed comperator reverse-sorts a Tree"
-            <| assertEqual reverseSortedTree
+        , test "Sorting with a Tree with a reversed comperator reverse-sorts a Tree" <|
+            assertEqual reverseSortedTree
                 (MultiwayTree.sortWith flippedComparison interestingTree)
         ]

--- a/tests/Test/TuplesOfDatumAndFlatChildrenTests.elm
+++ b/tests/Test/TuplesOfDatumAndFlatChildrenTests.elm
@@ -1,6 +1,6 @@
 module Test.TuplesOfDatumAndFlatChildrenTests exposing (..)
 
-import ElmTest exposing (..)
+import Legacy.ElmTest as ElmTest exposing (..)
 import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
 import Test.SampleData
@@ -17,14 +17,14 @@ import Test.SampleData
 tests : Test
 tests =
     suite "TuplesOfDatumAndFlatChildren"
-        [ test "TuplesOfDatumAndFlatChildren multiChildTree"
-            <| assertEqual [ ( "a", [ "b", "c", "d" ] ), ( "b", [] ), ( "c", [] ), ( "d", [] ) ]
+        [ test "TuplesOfDatumAndFlatChildren multiChildTree" <|
+            assertEqual [ ( "a", [ "b", "c", "d" ] ), ( "b", [] ), ( "c", [] ), ( "d", [] ) ]
                 (MultiwayTree.tuplesOfDatumAndFlatChildren multiChildTree)
-        , test "TuplesOfDatumAndFlatChildren deepTree"
-            <| assertEqual [ ( "a", [ "b", "c", "d" ] ), ( "b", [ "c", "d" ] ), ( "c", [ "d" ] ), ( "d", [] ) ]
+        , test "TuplesOfDatumAndFlatChildren deepTree" <|
+            assertEqual [ ( "a", [ "b", "c", "d" ] ), ( "b", [ "c", "d" ] ), ( "c", [ "d" ] ), ( "d", [] ) ]
                 (MultiwayTree.tuplesOfDatumAndFlatChildren deepTree)
-        , test "TuplesOfDatumAndFlatChildren interestingTree"
-            <| assertEqual
+        , test "TuplesOfDatumAndFlatChildren interestingTree" <|
+            assertEqual
                 [ ( "a", [ "b", "e", "k", "c", "f", "g", "d", "h", "i", "j" ] )
                 , ( "b", [ "e", "k" ] )
                 , ( "e", [ "k" ] )

--- a/tests/Test/UpdateTests.elm
+++ b/tests/Test/UpdateTests.elm
@@ -1,52 +1,58 @@
 module Test.UpdateTests exposing (..)
 
-import ElmTest exposing (..)
-
-import MultiwayTree exposing (Tree (..))
+import Legacy.ElmTest as ElmTest exposing (..)
+import MultiwayTree exposing (Tree(..))
 import MultiwayTreeZipper exposing (..)
-import Test.SampleData exposing
-    ( noChildTree, singleChildTree, multiChildTree, deepTree
-    , interestingTree, simpleForest
-    , noChildRecord )
+import Test.SampleData
+    exposing
+        ( noChildTree
+        , singleChildTree
+        , multiChildTree
+        , deepTree
+        , interestingTree
+        , simpleForest
+        , noChildRecord
+        )
+import Test.Utils exposing (..)
 
-(&>) = Maybe.andThen
 
 tests : Test
 tests =
     suite "Update"
-          [ test "Update datum (simple)"
-              <| assertEqual
-                  (Just (( Tree "ax" [] ), []))
-                  (Just (noChildTree, [])
-                    &> updateDatum (\a -> a ++ "x"))
-
-          , test "Update datum (record)"
-              <| assertEqual
-                  (Just (( Tree { selected = True, expanded = False } [] ), []))
-                  (Just (noChildRecord, [])
-                    &> updateDatum (\rec -> { rec | selected = True } ))
-
-          , test "Replace datum (simple)"
-              <| assertEqual
-                  (Just (( Tree "x" [] ), []))
-                  (Just (noChildTree, [])
-                    &> replaceDatum "x" )
-
-          , test "Replace datum (record)"
-              <| assertEqual
-                  (Just (( Tree { selected = True, expanded = True } [] ), []))
-                  (Just (noChildRecord, [])
-                    &> replaceDatum { selected = True, expanded = True } )
-
-          , test "Replace children (replace with empty)"
-              <| assertEqual
-                  (Just (noChildTree, []))
-                  (Just (singleChildTree, [])
-                    &> updateChildren [] )
-
-          , test "Replace children (replace with specific)"
-              <| assertEqual
-                  (Just (Tree "a" simpleForest, []))
-                  (Just (interestingTree, [])
-                    &> updateChildren simpleForest)
-          ]
+        [ test "Update datum (simple)" <|
+            assertEqual
+                (Just ( (Tree "ax" []), [] ))
+                (Just ( noChildTree, [] )
+                    &> updateDatum (\a -> a ++ "x")
+                )
+        , test "Update datum (record)" <|
+            assertEqual
+                (Just ( (Tree { selected = True, expanded = False } []), [] ))
+                (Just ( noChildRecord, [] )
+                    &> updateDatum (\rec -> { rec | selected = True })
+                )
+        , test "Replace datum (simple)" <|
+            assertEqual
+                (Just ( (Tree "x" []), [] ))
+                (Just ( noChildTree, [] )
+                    &> replaceDatum "x"
+                )
+        , test "Replace datum (record)" <|
+            assertEqual
+                (Just ( (Tree { selected = True, expanded = True } []), [] ))
+                (Just ( noChildRecord, [] )
+                    &> replaceDatum { selected = True, expanded = True }
+                )
+        , test "Replace children (replace with empty)" <|
+            assertEqual
+                (Just ( noChildTree, [] ))
+                (Just ( singleChildTree, [] )
+                    &> updateChildren []
+                )
+        , test "Replace children (replace with specific)" <|
+            assertEqual
+                (Just ( Tree "a" simpleForest, [] ))
+                (Just ( interestingTree, [] )
+                    &> updateChildren simpleForest
+                )
+        ]

--- a/tests/Test/Utils.elm
+++ b/tests/Test/Utils.elm
@@ -1,0 +1,15 @@
+module Test.Utils exposing (..)
+
+
+compatibleMaybeAndthen : Maybe a -> (a -> Maybe b) -> Maybe b
+compatibleMaybeAndthen maybe callback =
+    case maybe of
+        Just value ->
+            callback value
+
+        Nothing ->
+            Nothing
+
+
+(&>) =
+    compatibleMaybeAndthen

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,8 +1,8 @@
 module Tests exposing (..)
 
-import ElmTest exposing (..)
-
+import Legacy.ElmTest as ElmTest exposing (..)
 import Test.MultiwayTreeZipper as MultiwayTreeZipper
+
 
 all : Test
 all =
@@ -10,5 +10,7 @@ all =
         [ MultiwayTreeZipper.tests
         ]
 
-main : Program Never
-main = runSuite all
+
+main : Program Never () msg
+main =
+    runSuite all

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,8 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "rtfeldman/legacy-elm-test": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Upgrade to Elm 0.18.0 using elm-upgrade tool and good intentions.

**Questions/concerns**

- Not sure what to use for package version number in `elm-package.json`.  Bumped to `1.10.1` since no breaking changes as far as consumers are concerned.
- Unit tests are working, though I took a few shortcuts:
  - Used [`legacy-elm-test`](http://package.elm-lang.org/packages/rtfeldman/legacy-elm-test/latest) rather than update to `elm-test`
  - Hacked a compatible replacement for (&>) infix `Maybe.andThen` shortcut -- since `Maybe.andThen` parameters have been flipped in 0.18.0.    Perhaps there's a cleaner way to fix that, I'm open to suggestions.

